### PR TITLE
Test all known mirrors for an operational one

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,16 @@
 import os
-import urllib.request
+import urllib.request, urllib.error
 import sys
 import json
 
 DEST_DIR = "torrents"
+DOMAINS = [
+    'annas-archive.org',
+    'annas-archive.se',
+    'annas-archive.li',
+    'annas-archive.pm',
+    'annas-archive.in',
+]
 
 tb = input(
     "Please enter the number of terabytes of content to target (e.g., 0.05 for 50 GB, 10 for 10 TB; press Enter for no limit): ")
@@ -15,9 +22,25 @@ okay_to_download = input("Confirm download with Y / N: ")
 if not okay_to_download.upper() == "Y":
     sys.exit()
 
+# Find operational mirror
+domain = None
+for url in DOMAINS:
+    try:
+        req = urllib.request.Request('https://' + url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=5) as response:
+            if 200 <= response.status < 400:
+                print(f"Found operational mirror: {url}")
+                domain = url
+                break
+    except urllib.error.URLError:
+        continue
+if not domain:
+    print("No operational mirror found.")
+    sys.exit()
+
 print("Downloading torrent list...")
 
-with urllib.request.urlopen('https://annas-archive.org/dyn/generate_torrents?max_tb=' + str(tb) + '&format=json') as f:
+with urllib.request.urlopen(f'https://{domain}/dyn/generate_torrents?max_tb={tb}&format=json') as f:
     torrents = json.load(f)
     length = len(torrents)
     current = 1


### PR DESCRIPTION
The original .org domain has [recently](https://torrentfreak.com/annas-archive-loses-org-domain-after-surprise-suspension/) been suspended and is [currently](https://www.whois.com/whois/annas-archive.org) in [serverHold](https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en#serverHold) status, which breaks the script. This PR adds the list of all current official mirrors and iterates it to find the first operational one to latch onto before fetching the torrents, including the .org one in case it comes back live:
```
https://annas-archive.org/
https://annas-archive.se/
https://annas-archive.li/
https://annas-archive.pm/
https://annas-archive.in/
```