### PR TITLE
Update README links to use new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Anna's Torrents
 
 Help preserve the largest truly open library in human history!
-Python program to download torrent files that need seeding the most: go to [Anna's archive](https://annas-archive.org/torrents) for information.
+Python program to download torrent files that need seeding the most: go to [Anna's archive](https://annas-archive.li/torrents) for information.
 
-Now linked on Anna's Archive: [Generate torrent list](https://annas-archive.org/torrents#generate_torrent_list).
+Now linked on Anna's Archive: [Generate torrent list](https://annas-archive.li/torrents#generate_torrent_list).
 
 ## Usage
 


### PR DESCRIPTION
Replace links to `annas-archive.org` with `annas-archive.li` after the `.org` domain was seized.

The `.li` domain was used simply because it is at the top of the list on their [FAQ Page](https://annas-archive.li/faq#mirrors), and because the [Wikipedia page primary sources](https://en.wikipedia.org/wiki/Anna%27s_Archive#Primary_sources) use it.